### PR TITLE
fix(i18n-lint): fix missing bin

### DIFF
--- a/packages/i18n-lint/package.json
+++ b/packages/i18n-lint/package.json
@@ -2,9 +2,12 @@
   "name": "@m6web/i18n-lint",
   "version": "1.0.0",
   "description": "i18n translation files linter",
-  "main": "index.js",
+  "main": "lib/index.js",
   "author": "m6web",
   "license": "MIT",
+  "bin": {
+    "i18n-lint": "./lib/index.js"
+  },
   "devDependencies": {
     "@m6web/eslint-plugin": "2.0.0",
     "babel-cli": "6.26.0",

--- a/packages/i18n-lint/src/index.js
+++ b/packages/i18n-lint/src/index.js
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 import Runner from './runner';
 import defaultConfig from '../default.config';
 


### PR DESCRIPTION
- fix the package.json. Add the `i18n-lint` commande in order to run the module.
- add `#!/usr/bin/env node` in the index file.