### PR TITLE
test(yarn): upgrade yarn version for travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ node_js:
 cache: yarn
 
 before_install:
-  - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.6.0
+  - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.10.1
   - export PATH="$HOME/.yarn/bin:$PATH"
 
 script:


### PR DESCRIPTION
Upgrade yarn version for travis build. It seem's that the 1.6.0 is not available anymore 🤔 