### PR TITLE
feat(react-i18n): export tFunction from utils

### DIFF
--- a/packages/react-i18n/src/__tests__/index.spec.js
+++ b/packages/react-i18n/src/__tests__/index.spec.js
@@ -1,4 +1,4 @@
-import { Trans, translate, I18nProvider, translateFunction, useTranslate } from '../';
+import { Trans, translate, I18nProvider, translateFunction, useTranslate, tFunction } from '../';
 
 describe('index', () => {
   it('should export translate function', () => {
@@ -7,5 +7,6 @@ describe('index', () => {
     expect(typeof I18nProvider).toBe('function');
     expect(typeof translateFunction).toBe('function');
     expect(typeof useTranslate).toBe('function');
+    expect(typeof tFunction).toBe('function');
   });
 });

--- a/packages/react-i18n/src/index.js
+++ b/packages/react-i18n/src/index.js
@@ -5,3 +5,4 @@ export { Trans } from './components/i18nString.component';
 export { HtmlTrans } from './components/i18nElement.component';
 export { I18nProvider } from './components/i18n.provider';
 export { useTranslate } from './hooks/useTranslate';
+export { translate as tFunction } from './utils/i18n.utils';


### PR DESCRIPTION
# react-i18n

Export `tFunction` from utils, in order to use outside react context.