### PR TITLE
feat(react-i18n): add errorCallback for missing translations

### DIFF
--- a/packages/eslint-plugin-i18n/package.json
+++ b/packages/eslint-plugin-i18n/package.json
@@ -34,5 +34,6 @@
     "format": "prettier-eslint --write src/**/*.js",
     "test": "mocha --recursive tests",
     "prepack": "yarn test && yarn build"
-  }
+  },
+  "gitHead": "c2cec68fec1a8b532093d6fbb74c969a149039b4"
 }

--- a/packages/react-i18n/README.md
+++ b/packages/react-i18n/README.md
@@ -70,11 +70,11 @@ export default const MyComponent = ({ nbExample, t }) => {
 };
 ```
 
-- **i18nKeys**: key from the dictionary (required)
-- **number**: amount used for plural forms
-- **data**: object containing key/values used for interpolation in the translation
-- **general**: use general plural form if truthy
-- **renderers**: object containing the renderers to use to interpolate JSX (for more information see `JSX interpolation section`)
+* **i18nKeys**: key from the dictionary (required)
+* **number**: amount used for plural forms
+* **data**: object containing key/values used for interpolation in the translation
+* **general**: use general plural form if truthy
+* **renderers**: object containing the renderers to use to interpolate JSX (for more information see `JSX interpolation section`)
 
 ### i18n HTML component
 
@@ -95,12 +95,12 @@ export default const MyComponent = ({ nbExample, t }) => {
 };
 ```
 
-- **i18nKeys**: key from the dictionary (required)
-- **number**: amount used for plural forms
-- **data**: object containing key/values used for interpolation in the translation
-- **general**: use general plural form if truthy
-- **element**: HTML element, or React element used for rendering. (default value: `span`)
-- **renderers**: object containing the renderers to use to interpolate JSX (for more information see `JSX interpolation section`)
+* **i18nKeys**: key from the dictionary (required)
+* **number**: amount used for plural forms
+* **data**: object containing key/values used for interpolation in the translation
+* **general**: use general plural form if truthy
+* **element**: HTML element, or React element used for rendering. (default value: `span`)
+* **renderers**: object containing the renderers to use to interpolate JSX (for more information see `JSX interpolation section`)
 
 Note that **number** and **data** can be used together.
 
@@ -131,12 +131,12 @@ const MyComponent = ({ nbExample, t }) => {
 export default translate(MyComponent);
 ```
 
-- **t**: translation function, params are:
-- **key**: key from the dictionary (required)
-- **data**: object containing key/values used for interpolation in the translation
-- **number**: amount used for plural forms
-- **general**: use general plural form if truthy
-- **renderers**: object containing the renderers to use to interpolate JSX (for more information see `JSX interpolation section`)
+* **t**: translation function, params are:
+* **key**: key from the dictionary (required)
+* **data**: object containing key/values used for interpolation in the translation
+* **number**: amount used for plural forms
+* **general**: use general plural form if truthy
+* **renderers**: object containing the renderers to use to interpolate JSX (for more information see `JSX interpolation section`)
 
 Note that **number** and **data** can be used together.
 
@@ -231,7 +231,8 @@ const MyComponent = () => {
 
 In this example, the `<LinkToHome>` inside your translation will be rendered by the component given in `renderers`.
 
-For the moment only the children props are used by the renderer. 
+For the moment only the children props are used by the renderer.
+
 ```jsx harmony
 // Do
 <Link>Home</Link>

--- a/packages/react-i18n/README.md
+++ b/packages/react-i18n/README.md
@@ -35,9 +35,12 @@ const i18nNames = {
   company: 'm6'
 };
 
+// Callback in case of missing translation
+const errorCallback = console.warn;
+
 // Put your app in the provider
 const Root = () => (
-  <I18nProvider lang={translations} i18nNames={i18nNames} >
+  <I18nProvider lang={translations} i18nNames={i18nNames} errorCallback={errorCallback}>
     <App />
   </I18nProvider>
 );

--- a/packages/react-i18n/src/components/i18n.provider.js
+++ b/packages/react-i18n/src/components/i18n.provider.js
@@ -3,12 +3,13 @@ import PropTypes from 'prop-types';
 import { translate } from '../utils/i18n.utils';
 import { Context } from '../context/i18n.context';
 
-export const I18nProvider = ({ lang, i18nNames, children }) => (
-  <Context.Provider value={translate(lang, i18nNames)}>{children}</Context.Provider>
+export const I18nProvider = ({ lang, i18nNames, children, errorCallback }) => (
+  <Context.Provider value={translate(lang, i18nNames, errorCallback)}>{children}</Context.Provider>
 );
 
 I18nProvider.propTypes = {
   children: PropTypes.element.isRequired,
   lang: PropTypes.object.isRequired,
   i18nNames: PropTypes.object,
+  errorCallback: PropTypes.func,
 };

--- a/packages/react-i18n/src/utils/__tests__/i18n.utils.spec.js
+++ b/packages/react-i18n/src/utils/__tests__/i18n.utils.spec.js
@@ -10,6 +10,14 @@ describe('i18n translate function', () => {
     expect(translate({})('foo.bar')).toBe('foo.bar');
   });
 
+  it('should call the errorCallback if the translation is missing', () => {
+    const errorCallback = jest.fn();
+    expect(translate(undefined, undefined, errorCallback)('foo.bar')).toBe('foo.bar');
+    expect(errorCallback).toBeCalledWith('foo.bar');
+    expect(translate({}, undefined, errorCallback)('foo.foo')).toBe('foo.foo');
+    expect(errorCallback).toBeCalledWith('foo.foo');
+  });
+
   it('should return translation for a given key ', () => {
     const lang = { foo: { bar: 'foo bar!' } };
     expect(translate(lang)('foo.bar')).toBe('foo bar!');
@@ -167,7 +175,7 @@ describe('i18n translate function', () => {
   describe('with JSX', () => {
     const Bold = ({ children }) => <strong>{children}</strong>;
     const Italic = ({ children }) => <em>{children}</em>;
-    const LineBreak = () => <br />;
+    const LineBreak = () => <br/>;
 
     it('should render the JSX component present inside the translation', () => {
       const lang = {
@@ -278,17 +286,17 @@ describe('i18n translate function', () => {
     it('should works with badly formatted JSX', () => {
       const lang = {
         foo: {
-          bar: '<Bold>Toto</Italic>'
-        }
-      }
+          bar: '<Bold>Toto</Italic>',
+        },
+      };
 
-      const renderers = {Bold, Italic}
-      const t = translate(lang)
+      const renderers = { Bold, Italic };
+      const t = translate(lang);
 
-      const result = t('foo.bar', undefined, undefined, undefined, renderers)
-      const wrapper = mount(<div>{result}</div>)
+      const result = t('foo.bar', undefined, undefined, undefined, renderers);
+      const wrapper = mount(<div>{result}</div>);
 
-      expect(wrapper).toMatchSnapshot()
+      expect(wrapper).toMatchSnapshot();
     });
   });
 });

--- a/packages/react-i18n/src/utils/i18n.utils.js
+++ b/packages/react-i18n/src/utils/i18n.utils.js
@@ -116,7 +116,7 @@ const interpolateJSXInsideTranslation = (translation, renderers) => {
   return translationChildren;
 };
 
-export const translate = (lang, i18nNames = {}) => {
+export const translate = (lang, i18nNames = {}, errorCallback = _.noop) => {
   const pluralize = pluralizeFunctions[_.get(lang, '_i18n.lang')] || pluralizeFunctions.fr;
 
   return (key, data = {}, number, general, renderers) => {
@@ -126,7 +126,13 @@ export const translate = (lang, i18nNames = {}) => {
       combineKey = `${key}.${pluralize(number, general)}`;
     }
 
-    const translation = _.get(lang, combineKey, combineKey);
+    let translation;
+    if (_.has(lang, combineKey)) {
+      translation = _.get(lang, combineKey);
+    } else {
+      errorCallback(combineKey);
+      translation = combineKey;
+    }
 
     const translatedResult = sprintf(translation, { ...data, ...i18nNames, number });
     if (renderers) {


### PR DESCRIPTION
# Why
We need to monitor if some untranslated keys are displayed in production. For that we need the possibility to provide a callback for calling monitoring on untranslated keys

# How
I add an `errorCallback` parameter in translate function, with `_.noop` default value so the code remains backward compatible. The callback can be given as props in the Provider.

⚠️ I also run a quick `yarn format` 😅