### PR TITLE
docs(contributing): setup doc to explain how to release

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,17 @@
+# Contributing
+
+## How to release and publish packages ? 
+
+This monorepo uses the `lerna` tool for the management of multipackages. This tool also allows to publish the changelogs and automatically create the github releases associated to the git tag.
+
+To create a release, you just need to have the `GH_TOKEN` de variable defined in your shell and then execute the command:
+
+```
+GH_TOKEN=<your-github-token> yarn release
+``` 
+
+Once the releases have been created, all you have to do is publish them on NPM.
+
+```
+yarn lerna:publish
+```

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "prepack": "yarn lerna run prepack --stream",
     "test": "yarn lerna run test --stream",
     "test:ci": "yarn jest --coverage && yarn --cwd packages/eslint-plugin-i18n mocha --recursive tests",
-    "release": "yarn lerna version  --conventional-commits --create-release github"
+    "release": "yarn lerna version  --conventional-commits --create-release github",
+    "lerna:publish": "yarn lerna publish from-git"
   }
 }


### PR DESCRIPTION
## Why

We don't have any documentation on how releasing and publishing this package.

## How

Use lerna commands as _npm scripts_