### PR TITLE
feat(react-i18n): render HTML elements

### DIFF
--- a/packages/react-i18n/README.md
+++ b/packages/react-i18n/README.md
@@ -216,17 +216,125 @@ The variable used in translation template string has to be `%(number)d`, and is 
 
 To use general form, you need to set 4th parameter of the translate function to `true`
 
-### JSX Interpolation
+### HTML Interpolation
+Basic html tags are automatically interpolated in translation if the syntax is correct (opening tag should be close within the translation).
+
+Props are supported too.
+
+Basic textual interpolations are proceeded first, and the HTML comes in a second time.
+- translation
+```json
+{
+  "foo": {
+    "bar": "<a href=\"/page-%(number)s\">To page %(number)s</a>"
+  }
+}
+```
+- code
+```jsx
+import React from 'react';
+import { useTranslate } from './useTranslate';
+
+export const MyComponent = () => {
+  const t = useTranslate();
+
+  return (
+    <div class="foo">
+      <p>{t('foo.bar', { number: 2 })}</p>
+    </div>
+  );
+}
+```
+- result
+```jsx harmony
+<div>
+  <p>
+    <a href="/page-2">To page 2</a>
+  </p>
+</div>
+```
+
+#### keys
+In case of arrays of component, keys will be automatically generated to please React.
+- translation
+```js
+{
+  foo: {
+    bar:
+      '<h1>Test</h1>' +
+      '<p>This is not what we wanna do with this lib but we need to ensure it works anyway</p>' +
+      '<ul>' +
+      '<li>simple link to <a href="https://github.com/M6Web/i18n-tools" target="_blank">the package</a>.</li>' +
+      '<li>a disabled <button disabled>button</button></li>' +
+      '<li>and an auto closing br <br /></li>' +
+      '</ul>',
+  },
+};
+```
+- result
+```jsx harmony
+<div>
+  <h1
+    key="h1-0"
+  >
+    Test
+  </h1>
+  <p
+    key="p-1"
+  >
+    This is not what we wanna do with this lib but we need to ensure it works anyway
+  </p>
+  <ul
+    key="ul-2"
+  >
+    <li
+      key="li-0"
+    >
+      simple link to
+      <a
+        href="https://github.com/M6Web/i18n-tools"
+        key="a-1"
+        target="_blank"
+      >
+        the package
+      </a>
+      .
+    </li>
+    <li
+      key="li-1"
+    >
+      a disabled
+      <button
+        disabled={true}
+        key="button-1"
+      >
+        button
+      </button>
+    </li>
+    <li
+      key="li-2"
+    >
+      and an auto closing br
+      <br
+        key="br-1"
+      />
+    </li>
+  </ul>
+</div>
+```
+
+#### JSX Interpolation
 
 It is possible to interpolate JSX components inside translation, to do so you have to give `renderers` parameter or props.
 For example if you have in your translation : `foo <LinkToHome>bar</LinkToHome>` you should have a `LinkToHome` renderer.
 
 ```jsx harmony
 import React from 'react';
+import { Link } from 'react-router-dom';
 import { useTranslate } from '@m6web/react-i18n';
 
 const renderers = {
-  LinkToHome: ({ children }) => <a href="/">{children}</a>,
+  LinkToHome: ({ children }) => <Link to="home">{children}</Link>,
 };
 
 const MyComponent = () => {
@@ -242,13 +350,4 @@ const MyComponent = () => {
 
 In this example, the `<LinkToHome>` inside your translation will be rendered by the component given in `renderers`.
 
-For the moment only the children props are used by the renderer.
-
-```jsx harmony
-// Do
-<Link>Home</Link>
-<Link /> or <Link/>
-
-// Don't
-<Link href="/home">Home</Link>
-```
+Props are also supported.

--- a/packages/react-i18n/README.md
+++ b/packages/react-i18n/README.md
@@ -48,13 +48,22 @@ const errorCallback = console.warn;
 
 // Put your app in the provider
 const Root = () => (
-  <I18nProvider lang={translations} i18nNames={i18nNames} errorCallback={errorCallback}>
+  <I18nProvider lang={translations} i18nNames={i18nNames} errorCallback={errorCallback} parseHTML>
     <App />
   </I18nProvider>
 );
 ```
 
 ## Use translation components
+
+### i18n Provider
+This component will provide the translation function to following components via the React.Context api.
+
+* **lang**: translation dictionary
+* **i18nNames**: static translation values for interpolation
+* **errorCallback**: callback triggered when an error happens during the execution of the translation function
+* **parseHTML**: activates parsing of HTML inside translation
+* **children**: your App main component
 
 ### i18n String component
 
@@ -67,7 +76,7 @@ import { Trans } from '@m6web/react-i18n';
 // Interpolation values
 const data = { element: 'foo' };
 
-export default const MyComponent = ({ nbExample, t }) => {
+export const MyComponent = ({ nbExample, t }) => {
   return (
     <div class="foo">
       <h1>
@@ -96,7 +105,7 @@ import { HtmlTrans } from '@m6web/react-i18n';
 // Interpolation values
 const data = { element: 'foo' };
 
-export default const MyComponent = ({ nbExample, t }) => {
+export const MyComponent = ({ nbExample, t }) => {
   return (
     <div class="foo">
       <HtmlTrans i18nKey="foo.bar" element="h1" />
@@ -219,7 +228,7 @@ To use general form, you need to set 4th parameter of the translate function to 
 ### HTML Interpolation
 Basic html tags are automatically interpolated in translation if the syntax is correct (opening tag should be close within the translation).
 
-Props are supported too.
+Attributes are supported too.
 
 Basic textual interpolations are proceeded first, and the HTML comes in a second time.
 - translation
@@ -254,6 +263,9 @@ export const MyComponent = () => {
 </div>
 ```
 
+#### excluded elements
+For now `script` and `iframe` elements are ignored with all their children in the HTML tree.  
+
 #### keys
 In case of arrays of component, keys will be automatically generated to please React.
 - translation
@@ -267,8 +279,8 @@ In case of arrays of component, keys will be automatically generated to please R
       '<li>simple link to <a href="https://github.com/M6Web/i18n-tools" target="_blank">the package</a>.</li>' +
       '<li>a disabled <button disabled>button</button></li>' +
       '<li>and an auto closing br <br /></li>' +
-      '</ul>',
-  },
+      '</ul>'
+  }
 };
 ```
 - result
@@ -350,4 +362,6 @@ const MyComponent = () => {
 
 In this example, the `<LinkToHome>` inside your translation will be rendered by the component given in `renderers`.
 
-Props are also supported.
+Attributes are also supported.
+
+:warning: If the translation contains an unknown tag, the translation will be display without HTML parsing.

--- a/packages/react-i18n/src/components/i18n.provider.js
+++ b/packages/react-i18n/src/components/i18n.provider.js
@@ -3,13 +3,14 @@ import PropTypes from 'prop-types';
 import { translate } from '../utils/i18n.utils';
 import { Context } from '../context/i18n.context';
 
-export const I18nProvider = ({ lang, i18nNames, children, errorCallback }) => (
-  <Context.Provider value={translate(lang, i18nNames, errorCallback)}>{children}</Context.Provider>
+export const I18nProvider = ({ lang, i18nNames, children, errorCallback, parseHTML }) => (
+  <Context.Provider value={translate(lang, i18nNames, errorCallback, parseHTML)}>{children}</Context.Provider>
 );
 
 I18nProvider.propTypes = {
   children: PropTypes.element.isRequired,
   lang: PropTypes.object.isRequired,
+  parseHTML: PropTypes.bool,
   i18nNames: PropTypes.object,
   errorCallback: PropTypes.func,
 };

--- a/packages/react-i18n/src/utils/__tests__/__snapshots__/i18n.utils.spec.js.snap
+++ b/packages/react-i18n/src/utils/__tests__/__snapshots__/i18n.utils.spec.js.snap
@@ -13,12 +13,6 @@ exports[`i18n translate function with JSX should interpolate basic html tag 1`] 
 </div>
 `;
 
-exports[`i18n translate function with JSX should not try to interpolate basic html tag 1`] = `
-<div>
-  &lt;em&gt;Hello&lt;/em&gt; &lt;strong&gt;Moto&lt;/strong&gt; !
-</div>
-`;
-
 exports[`i18n translate function with JSX should render a complex JSX structure inside the translation 1`] = `
 <div>
   <Bold>

--- a/packages/react-i18n/src/utils/__tests__/__snapshots__/i18n.utils.spec.js.snap
+++ b/packages/react-i18n/src/utils/__tests__/__snapshots__/i18n.utils.spec.js.snap
@@ -1,5 +1,18 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`i18n translate function with JSX should interpolate basic html tag 1`] = `
+<div>
+  <em>
+    Hello
+  </em>
+   
+  <strong>
+    Moto
+  </strong>
+   !
+</div>
+`;
+
 exports[`i18n translate function with JSX should not try to interpolate basic html tag 1`] = `
 <div>
   &lt;em&gt;Hello&lt;/em&gt; &lt;strong&gt;Moto&lt;/strong&gt; !
@@ -86,6 +99,34 @@ exports[`i18n translate function with JSX should render the short (without child
   </LineBreak>
    !
 </div>
+`;
+
+exports[`i18n translate function with JSX should return un-interpolated translation when a renderer is missing 1`] = `
+Array [
+  "Hello ",
+  <Bold>
+    &lt;Italic&gt;
+    Moto
+    &lt;/Italic&gt;
+  </Bold>,
+  " !",
+]
+`;
+
+exports[`i18n translate function with JSX should return un-interpolated translation when a renderer is missing 2`] = `
+Array [
+  "Hello ",
+  Array [
+    "<Bold>",
+    Array [
+      <Italic>
+        Moto
+      </Italic>,
+    ],
+    "</Bold>",
+  ],
+  " !",
+]
 `;
 
 exports[`i18n translate function with JSX should works with badly formatted JSX 1`] = `

--- a/packages/react-i18n/src/utils/__tests__/__snapshots__/i18n.utils.spec.js.snap
+++ b/packages/react-i18n/src/utils/__tests__/__snapshots__/i18n.utils.spec.js.snap
@@ -33,7 +33,7 @@ exports[`i18n translate function with JSX should correctly render a big chunck o
     >
       a disabled 
       <button
-        disabled={null}
+        disabled={true}
         key="button-1"
       >
         button

--- a/packages/react-i18n/src/utils/__tests__/__snapshots__/i18n.utils.spec.js.snap
+++ b/packages/react-i18n/src/utils/__tests__/__snapshots__/i18n.utils.spec.js.snap
@@ -2,11 +2,15 @@
 
 exports[`i18n translate function with JSX should interpolate basic html tag 1`] = `
 <div>
-  <em>
+  <em
+    key="em-0"
+  >
     Hello
   </em>
    
-  <strong>
+  <strong
+    key="strong-2"
+  >
     Moto
   </strong>
    !
@@ -15,9 +19,13 @@ exports[`i18n translate function with JSX should interpolate basic html tag 1`] 
 
 exports[`i18n translate function with JSX should render a complex JSX structure inside the translation 1`] = `
 <div>
-  <Bold>
+  <Bold
+    key="Bold-0"
+  >
     <strong>
-      <Italic>
+      <Italic
+        key="Italic-0"
+      >
         <em>
           Hell
         </em>
@@ -25,11 +33,15 @@ exports[`i18n translate function with JSX should render a complex JSX structure 
       o
     </strong>
   </Bold>
-  <LineBreak>
+  <LineBreak
+    key="LineBreak-1"
+  >
     <br />
   </LineBreak>
   Moto
-  <LineBreak>
+  <LineBreak
+    key="LineBreak-3"
+  >
     <br />
   </LineBreak>
    !
@@ -38,13 +50,17 @@ exports[`i18n translate function with JSX should render a complex JSX structure 
 
 exports[`i18n translate function with JSX should render the JSX component and sibling JSX component present inside the translation 1`] = `
 <div>
-  <Italic>
+  <Italic
+    key="Italic-0"
+  >
     <em>
       Hello
     </em>
   </Italic>
    
-  <Bold>
+  <Bold
+    key="Bold-2"
+  >
     <strong>
       Moto
     </strong>
@@ -56,7 +72,9 @@ exports[`i18n translate function with JSX should render the JSX component and si
 exports[`i18n translate function with JSX should render the JSX component present inside the translation 1`] = `
 <div>
   Hello 
-  <Bold>
+  <Bold
+    key="Bold-1"
+  >
     <strong>
       Moto
     </strong>
@@ -68,7 +86,9 @@ exports[`i18n translate function with JSX should render the JSX component presen
 exports[`i18n translate function with JSX should render the nested JSX component present inside the translation 1`] = `
 <div>
   Hello 
-  <Bold>
+  <Bold
+    key="Bold-1"
+  >
     <strong>
       <Italic>
         <em>
@@ -84,11 +104,15 @@ exports[`i18n translate function with JSX should render the nested JSX component
 exports[`i18n translate function with JSX should render the short (without children) JSX component inside the translation 1`] = `
 <div>
   Hello
-  <LineBreak>
+  <LineBreak
+    key="LineBreak-1"
+  >
     <br />
   </LineBreak>
   Moto
-  <LineBreak>
+  <LineBreak
+    key="LineBreak-3"
+  >
     <br />
   </LineBreak>
    !
@@ -110,15 +134,11 @@ Array [
 exports[`i18n translate function with JSX should return un-interpolated translation when a renderer is missing 2`] = `
 Array [
   "Hello ",
-  Array [
-    "<Bold>",
-    Array [
-      <Italic>
-        Moto
-      </Italic>,
-    ],
-    "</Bold>",
-  ],
+  "<Bold>",
+  <Italic>
+    Moto
+  </Italic>,
+  "</Bold>",
   " !",
 ]
 `;

--- a/packages/react-i18n/src/utils/__tests__/__snapshots__/i18n.utils.spec.js.snap
+++ b/packages/react-i18n/src/utils/__tests__/__snapshots__/i18n.utils.spec.js.snap
@@ -1,5 +1,56 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`i18n translate function with JSX should correctly render a big chunck of HTML 1`] = `
+<div>
+  <h1
+    key="h1-0"
+  >
+    Test
+  </h1>
+  <p
+    key="p-1"
+  >
+    This is not what we wanna do with this lib but we need to ensure it works anyway
+  </p>
+  <ul
+    key="ul-2"
+  >
+    <li
+      key="li-0"
+    >
+      simple link to 
+      <a
+        href="https://github.com/M6Web/i18n-tools"
+        key="a-1"
+        target="_blank"
+      >
+        the package
+      </a>
+      .
+    </li>
+    <li
+      key="li-1"
+    >
+      a disabled 
+      <button
+        disabled={null}
+        key="button-1"
+      >
+        button
+      </button>
+    </li>
+    <li
+      key="li-2"
+    >
+      and an auto closing br 
+      <br
+        key="br-1"
+      />
+    </li>
+  </ul>
+</div>
+`;
+
 exports[`i18n translate function with JSX should interpolate basic html tag 1`] = `
 <div>
   <em

--- a/packages/react-i18n/src/utils/__tests__/i18n.utils.spec.js
+++ b/packages/react-i18n/src/utils/__tests__/i18n.utils.spec.js
@@ -184,7 +184,7 @@ describe('i18n translate function', () => {
         },
       };
       const renderers = { Bold };
-      const t = translate(lang);
+      const t = translate(lang, undefined, undefined, true);
 
       const result = t('foo.bar', undefined, undefined, false, renderers);
       const wrapper = mount(<div>{result}</div>);
@@ -199,7 +199,7 @@ describe('i18n translate function', () => {
         },
       };
       const renderers = { Bold, Italic };
-      const t = translate(lang);
+      const t = translate(lang, undefined, undefined, true);
 
       const result = t('foo.bar', undefined, undefined, false, renderers);
       const wrapper = mount(<div>{result}</div>);
@@ -214,7 +214,7 @@ describe('i18n translate function', () => {
         },
       };
       const renderers = { Bold, Italic };
-      const t = translate(lang);
+      const t = translate(lang, undefined, undefined, true);
 
       const result = t('foo.bar', undefined, undefined, false, renderers);
       const wrapper = mount(<div>{result}</div>);
@@ -229,7 +229,7 @@ describe('i18n translate function', () => {
         },
       };
       const renderers = { LineBreak };
-      const t = translate(lang);
+      const t = translate(lang, undefined, undefined, true);
 
       const result = t('foo.bar', undefined, undefined, false, renderers);
       const wrapper = mount(<div>{result}</div>);
@@ -244,7 +244,7 @@ describe('i18n translate function', () => {
         },
       };
       const renderers = { LineBreak, Bold, Italic };
-      const t = translate(lang);
+      const t = translate(lang, undefined, undefined, true);
 
       const result = t('foo.bar', undefined, undefined, false, renderers);
       const wrapper = mount(<div>{result}</div>);
@@ -258,7 +258,7 @@ describe('i18n translate function', () => {
           bar: 'Hello <Bold><Italic>Moto</Italic></Bold> !',
         },
       };
-      const t = translate(lang);
+      const t = translate(lang, undefined, undefined, true);
 
       expect(t('foo.bar', undefined, undefined, false, { Bold })).toMatchSnapshot();
       expect(t('foo.bar', undefined, undefined, false, { Italic })).toMatchSnapshot();
@@ -271,7 +271,7 @@ describe('i18n translate function', () => {
         },
       };
       const renderers = {};
-      const t = translate(lang);
+      const t = translate(lang, undefined, undefined, true);
 
       const result = t('foo.bar', undefined, undefined, false, renderers);
       const wrapper = mount(<div>{result}</div>);
@@ -287,7 +287,7 @@ describe('i18n translate function', () => {
       };
 
       const renderers = { Bold, Italic };
-      const t = translate(lang);
+      const t = translate(lang, undefined, undefined, true);
 
       const result = t('foo.bar', undefined, undefined, undefined, renderers);
       const wrapper = mount(<div>{result}</div>);
@@ -295,7 +295,7 @@ describe('i18n translate function', () => {
       expect(wrapper).toMatchSnapshot();
     });
 
-    it('should correctly render a big chunck of HTML', () => {
+    fit('should correctly render a big chunck of HTML', () => {
       const lang = {
         foo: {
           bar:
@@ -305,11 +305,13 @@ describe('i18n translate function', () => {
             '<li>simple link to <a href="https://github.com/M6Web/i18n-tools" target="_blank">the package</a>.</li>' +
             '<li>a disabled <button disabled>button</button></li>' +
             '<li>and an auto closing br <br /></li>' +
+            '<script type="application/javascript">Some script I don\'t wanna see</script>' +
+            '<iframe src="Some iframe I don\'t wanna see" />' +
             '</ul>',
         },
       };
 
-      const t = translate(lang);
+      const t = translate(lang, undefined, undefined, true);
       const wrapper = mount(<div>{t('foo.bar', undefined, undefined, undefined, {})}</div>);
 
       expect(wrapper).toMatchSnapshot();

--- a/packages/react-i18n/src/utils/__tests__/i18n.utils.spec.js
+++ b/packages/react-i18n/src/utils/__tests__/i18n.utils.spec.js
@@ -175,7 +175,7 @@ describe('i18n translate function', () => {
   describe('with JSX', () => {
     const Bold = ({ children }) => <strong>{children}</strong>;
     const Italic = ({ children }) => <em>{children}</em>;
-    const LineBreak = () => <br/>;
+    const LineBreak = () => <br />;
 
     it('should render the JSX component present inside the translation', () => {
       const lang = {
@@ -291,6 +291,26 @@ describe('i18n translate function', () => {
 
       const result = t('foo.bar', undefined, undefined, undefined, renderers);
       const wrapper = mount(<div>{result}</div>);
+
+      expect(wrapper).toMatchSnapshot();
+    });
+
+    it('should correctly render a big chunck of HTML', () => {
+      const lang = {
+        foo: {
+          bar:
+            '<h1>Test</h1>' +
+            '<p>This is not what we wanna do with this lib but we need to ensure it works anyway</p>' +
+            '<ul>' +
+            '<li>simple link to <a href="https://github.com/M6Web/i18n-tools" target="_blank">the package</a>.</li>' +
+            '<li>a disabled <button disabled>button</button></li>' +
+            '<li>and an auto closing br <br /></li>' +
+            '</ul>',
+        },
+      };
+
+      const t = translate(lang);
+      const wrapper = mount(<div>{t('foo.bar', undefined, undefined, undefined, {})}</div>);
 
       expect(wrapper).toMatchSnapshot();
     });

--- a/packages/react-i18n/src/utils/__tests__/i18n.utils.spec.js
+++ b/packages/react-i18n/src/utils/__tests__/i18n.utils.spec.js
@@ -252,23 +252,19 @@ describe('i18n translate function', () => {
       expect(wrapper).toMatchSnapshot();
     });
 
-    /* eslint-disable no-console */
-    it('should throw an error if renderer not provided', () => {
-      console.warn = jest.fn();
+    it('should return un-interpolated translation when a renderer is missing', () => {
       const lang = {
         foo: {
           bar: 'Hello <Bold><Italic>Moto</Italic></Bold> !',
         },
       };
-      const renderers = { Bold };
       const t = translate(lang);
-      t('foo.bar', undefined, undefined, false, renderers);
 
-      expect(console.warn).toHaveBeenCalledWith('No renderer provided for component "Italic"');
+      expect(t('foo.bar', undefined, undefined, false, { Bold })).toMatchSnapshot();
+      expect(t('foo.bar', undefined, undefined, false, { Italic })).toMatchSnapshot();
     });
-    /* eslint-enable no-console */
 
-    it('should not try to interpolate basic html tag', () => {
+    it('should interpolate basic html tag', () => {
       const lang = {
         foo: {
           bar: '<em>Hello</em> <strong>Moto</strong> !',

--- a/packages/react-i18n/src/utils/html.utils.js
+++ b/packages/react-i18n/src/utils/html.utils.js
@@ -3,7 +3,7 @@ import _ from 'lodash';
 
 const upperCase = /^[A-Z]/;
 const tagSearch = /(<.+?>)/;
-const tagNameSearch = /<\/?([A-z]+)/;
+const tagNameSearch = /<\/?(h[1-6]|[A-z]+)/;
 
 const parseProps = props => {
   if (!props.length) {

--- a/packages/react-i18n/src/utils/html.utils.js
+++ b/packages/react-i18n/src/utils/html.utils.js
@@ -5,19 +5,21 @@ const upperCase = /^[A-Z]/;
 const tagSearch = /(<.+?>)/;
 const tagNameSearch = /<\/?(h[1-6]|[A-z]+)/;
 
-const parseProps = props => {
-  if (!props.length) {
-    return null;
+const propsMapper = prop => {
+  const [key, value = true] = prop.split('=');
+
+  if (key) {
+    if (value === true) {
+      return { key, value: true };
+    }
+
+    return { key, value: typeof value === 'string' ? JSON.parse(value) : null };
   }
 
-  return _.compact(
-    props.map(prop => {
-      const [key, value = true] = prop.split('=');
-
-      return key ? { key, value: typeof value === 'string' ? JSON.parse(value) : null } : null;
-    }),
-  );
+  return null;
 };
+
+const parseProps = props => (props.length ? _.compact(props.map(propsMapper)) : null);
 
 const analyseTag = tag => {
   const isAutoClosing = tag[tag.length - 2] === '/';

--- a/packages/react-i18n/src/utils/html.utils.js
+++ b/packages/react-i18n/src/utils/html.utils.js
@@ -73,9 +73,7 @@ const buildProps = (serialisedProps, key) => {
   return props;
 };
 
-const getKey = (tagName, index) => {
-  return `${tagName}-${index}`;
-};
+const getKey = (tagName, index) => `${tagName}-${index}`;
 
 const renderer = (tree, renderers = {}) => {
   // Generate keys for React and HTML element in arrays

--- a/packages/react-i18n/src/utils/html.utils.js
+++ b/packages/react-i18n/src/utils/html.utils.js
@@ -1,0 +1,115 @@
+import React from 'react';
+import _ from 'lodash';
+
+const upperCase = /^[A-Z]/;
+const tagSearch = /(<.+?>)/;
+const tagNameSearch = /<\/?([A-z]+)/;
+
+const parseProps = props => {
+  if (!props.length) {
+    return null;
+  }
+
+  return _.compact(
+    props.map(prop => {
+      const [key, value = true] = prop.split('=');
+
+      return key ? { key, value: typeof value === 'string' ? JSON.parse(value) : null } : null;
+    }),
+  );
+};
+
+const analyseTag = tag => {
+  const isAutoClosing = tag[tag.length - 2] === '/';
+  const isClosing = tag[1] === '/';
+  const tagName = tagNameSearch.exec(tag)[1];
+  const isReactComponent = upperCase.test(tagName);
+  const props = isClosing
+    ? null
+    : parseProps(tag.slice(tag.indexOf(tagName) + tagName.length + 1, tag.length - (isAutoClosing ? 2 : 1)).split(' '));
+
+  return {
+    isAutoClosing,
+    isClosing,
+    isReactComponent,
+    tagName,
+    props,
+    raw: tag,
+  };
+};
+
+const buildTree = (elements, config = { currentIndex: 0 }, tree = [], currentTagName) => {
+  while (config.currentIndex < elements.length) {
+    const element = elements[config.currentIndex];
+
+    // eslint-disable-next-line no-param-reassign,no-plusplus
+    config.currentIndex++;
+
+    if (typeof element === 'object') {
+      if (element.isClosing && element.tagName === currentTagName) {
+        return tree;
+      }
+
+      if (!element.isAutoClosing && !element.isClosing) {
+        element.children = [];
+        buildTree(elements, config, element.children, element.tagName);
+      }
+    }
+
+    tree.push(element);
+  }
+
+  if (currentTagName) throw new Error(`Malformated HMTL, can't build proper render`);
+
+  return tree;
+};
+
+const buildProps = props => props.reduce((acc, { key, value }) => ({ ...acc, [key]: value }), {});
+
+const renderer = (tree, renderers = {}) =>
+  tree.map(node => {
+    if (typeof node === 'object') {
+      if (node.isReactComponent) {
+        if (renderers[node.tagName]) {
+          return React.createElement(
+            renderers[node.tagName],
+            buildProps(node.props),
+            node.isAutoClosing ? undefined : renderer(node.children, renderers),
+          );
+        }
+
+        const fallback = [node.raw];
+        if (node.children.length) {
+          fallback.push(renderer(node.children, renderers));
+          fallback.push(`</${node.tagName}>`);
+        }
+
+        return fallback;
+      }
+
+      return React.createElement(
+        node.tagName,
+        buildProps(node.props),
+        node.isAutoClosing ? undefined : renderer(node.children, renderers),
+      );
+    }
+
+    return node;
+  });
+
+export const interpolateHTMLTags = (translation, renderers) => {
+  const tags = _.compact(translation.split(tagSearch), x => x !== '').reduce(
+    (acc, element) => acc.concat(element[0] === '<' ? analyseTag(element) : element),
+    [],
+  );
+
+  if (tags.length === 1) return tags;
+
+  try {
+    const tree = buildTree(tags);
+
+    return renderer(tree, renderers);
+  } catch (error) {
+    return translation;
+  }
+};

--- a/packages/react-i18n/src/utils/i18n.utils.js
+++ b/packages/react-i18n/src/utils/i18n.utils.js
@@ -36,7 +36,7 @@ const pluralizeFunctions = {
   },
 };
 
-export const translate = (lang, i18nNames = {}, errorCallback = _.noop) => {
+export const translate = (lang, i18nNames = {}, errorCallback = _.noop, parseHTML = false) => {
   const pluralize = pluralizeFunctions[_.get(lang, '_i18n.lang')] || pluralizeFunctions.fr;
 
   return (key, data = {}, number, general, renderers) => {
@@ -55,6 +55,8 @@ export const translate = (lang, i18nNames = {}, errorCallback = _.noop) => {
     }
 
     const translatedResult = sprintf(translation, { ...data, ...i18nNames, number });
+
+    if (!parseHTML) return translatedResult;
 
     const htmlTags = interpolateHTMLTags(translatedResult, renderers);
     if (htmlTags.length > 1) return htmlTags;

--- a/packages/react-i18n/src/utils/i18n.utils.js
+++ b/packages/react-i18n/src/utils/i18n.utils.js
@@ -1,6 +1,6 @@
-import React from 'react';
 import _ from 'lodash';
 import { sprintf } from 'sprintf-js';
+import { interpolateHTMLTags } from './html.utils';
 
 const pluralizeFunctions = {
   en: number => (number === 0 || number > 1 ? 'other' : 'one'),
@@ -36,86 +36,6 @@ const pluralizeFunctions = {
   },
 };
 
-// find tags like : <Something>with content inside</Something>
-const JSX_TAG_WITH_CONTENT_REGEX = /(.*?)<([A-Z]\w+)>(.*)<\/\2+>(.*)/;
-// find tags like : <Something />
-const SHORT_JSX_TAG_REGEX = /(.*?)<([A-Z]\w+) ?\/>(.*)/;
-
-const parseJSX = content => {
-  const regexResultTagWithContent = JSX_TAG_WITH_CONTENT_REGEX.exec(content);
-  if (regexResultTagWithContent) {
-    return {
-      beforeTagContent: regexResultTagWithContent[1],
-      componentTag: regexResultTagWithContent[2],
-      insideTagContent: regexResultTagWithContent[3],
-      afterTagContent: regexResultTagWithContent[4],
-    };
-  }
-
-  const regexResultShortTag = SHORT_JSX_TAG_REGEX.exec(content);
-  if (regexResultShortTag) {
-    return {
-      beforeTagContent: regexResultShortTag[1],
-      componentTag: regexResultShortTag[2],
-      afterTagContent: regexResultShortTag[3],
-    };
-  }
-
-  return null;
-};
-
-const createComponentInstance = (component, children) => {
-  if (!component) {
-    return null;
-  }
-
-  return React.createElement(component, {}, ...(Array.isArray(children) ? children : [children]));
-};
-
-const interpolateJSXInsideTranslation = (translation, renderers) => {
-  const parsingResult = parseJSX(translation);
-  if (!parsingResult) {
-    return translation;
-  }
-
-  const { beforeTagContent, componentTag, insideTagContent, afterTagContent } = parsingResult;
-  const translationChildren = [];
-  const interpolateAndAddToChildren = content => {
-    const interpolatedContent = interpolateJSXInsideTranslation(content, renderers);
-
-    if (typeof interpolatedContent === 'string') {
-      translationChildren.push(interpolatedContent);
-    }
-
-    if (Array.isArray(interpolatedContent)) {
-      translationChildren.push(...interpolatedContent);
-    }
-  };
-
-  if (beforeTagContent) {
-    interpolateAndAddToChildren(beforeTagContent);
-  }
-
-  if (componentTag) {
-    const interpolatedChildren = insideTagContent ? interpolateJSXInsideTranslation(insideTagContent, renderers) : null;
-    const rendererToUse = renderers[componentTag];
-    const componentInstance = createComponentInstance(rendererToUse, interpolatedChildren);
-
-    if (componentInstance) {
-      translationChildren.push(componentInstance);
-    } else {
-      // eslint-disable-next-line no-console
-      console.warn(`No renderer provided for component "${componentTag}"`);
-    }
-  }
-
-  if (afterTagContent) {
-    interpolateAndAddToChildren(afterTagContent);
-  }
-
-  return translationChildren;
-};
-
 export const translate = (lang, i18nNames = {}, errorCallback = _.noop) => {
   const pluralize = pluralizeFunctions[_.get(lang, '_i18n.lang')] || pluralizeFunctions.fr;
 
@@ -135,11 +55,9 @@ export const translate = (lang, i18nNames = {}, errorCallback = _.noop) => {
     }
 
     const translatedResult = sprintf(translation, { ...data, ...i18nNames, number });
-    if (renderers) {
-      const JSXTranslated = interpolateJSXInsideTranslation(translatedResult, renderers);
 
-      return createComponentInstance(React.Fragment, JSXTranslated);
-    }
+    const htmlTags = interpolateHTMLTags(translatedResult, renderers);
+    if (htmlTags.length > 1) return htmlTags;
 
     return translatedResult;
   };


### PR DESCRIPTION
## Why
We would like our customer to be able to add some HTML in their translation.

## How
Parse translation and render HTML tags with react.
- classic interpolation for text and numbers is performed first
- props are supported
- JSX interpolation now use the parser
- iframe and script tags are ignored (with all their children)

By default the feature is off. You need to activate it by setting the `parseHTML` attribute to `true` in the Provider
