### PR TITLE
feat(i18n-lint): use .eslintrc.json as translation files path source

### DIFF
--- a/packages/i18n-lint/src/index.js
+++ b/packages/i18n-lint/src/index.js
@@ -1,6 +1,14 @@
 #!/usr/bin/env node
 import Runner from './runner';
-import defaultConfig from '../default.config';
+import ConfigLoader from './configLoader';
+
+let defaultConfig;
+
+try {
+  defaultConfig = ConfigLoader.load(`.eslintrc.json`);
+} catch (e) {
+  console.info('No .eslintrc.json was found. Using --config...');
+}
 
 const runner = new Runner(defaultConfig);
 runner.run();

--- a/packages/i18n-lint/src/reader.js
+++ b/packages/i18n-lint/src/reader.js
@@ -1,11 +1,9 @@
 import fs from 'fs';
 
 export default class JSONReader {
-  static parse(folderName, fileName) {
+  static parse(filePath) {
     try {
-      const path = `${folderName}/${fileName}`;
-
-      const text = fs.readFileSync(path, 'utf-8');
+      const text = fs.readFileSync(filePath, 'utf-8');
 
       return JSON.parse(text);
     } catch (e) {

--- a/packages/i18n-lint/src/runner.js
+++ b/packages/i18n-lint/src/runner.js
@@ -23,12 +23,16 @@ export default class Runner {
   }
 
   run() {
-    const { mainLanguages, path } = this.config;
+    const {
+      settings: {
+        i18n: { principalLangs = [], secondaryLangs = [] },
+      },
+    } = this.config;
 
-    const reports = _.flatMap(mainLanguages, lang => {
-      const tradForLang = Reader.parse(path, `${lang}.json`);
+    const reports = _.flatMap([...principalLangs, ...secondaryLangs], ({ name, translationPath }) => {
+      const tradForLang = Reader.parse(translationPath);
 
-      return _.flatMap(reporters, reporter => reporter(tradForLang, lang));
+      return _.flatMap(reporters, (reporter) => reporter(tradForLang, name));
     });
 
     process.exit(_.find(reports, { error: true }) ? 1 : 0);

--- a/packages/i18n-lint/tests/test.config.json
+++ b/packages/i18n-lint/tests/test.config.json
@@ -1,3 +1,12 @@
 {
-  "path": "./tests/i18n"
+  "settings": {
+    "i18n": {
+      "principalLangs": [
+        {
+          "name": "test-en",
+          "translationPath": "./tests/i18n/en.json"
+        }
+      ]
+    }
+  }
 }


### PR DESCRIPTION
### why  ?
As the translation files architecture changed, we need to update how the linter find those files.

### how ?
i18n conf already exists for the eslint plugin in the .eslintrc.json file.
The "i18n-lint" command could use this file to know where translation files are located.
