### PR TITLE
fix(i18n-lint): improve opening tag regexp

### DIFF
--- a/packages/i18n-lint/src/verifiers/__tests__/__snapshots__/htmlVerifier.spec.js.snap
+++ b/packages/i18n-lint/src/verifiers/__tests__/__snapshots__/htmlVerifier.spec.js.snap
@@ -34,5 +34,9 @@ Array [
     "error": true,
     "message": "has double white space with inner html tag",
   },
+  Object {
+    "error": true,
+    "message": "has missing html tag",
+  },
 ]
 `;

--- a/packages/i18n-lint/src/verifiers/__tests__/htmlVerifier.spec.js
+++ b/packages/i18n-lint/src/verifiers/__tests__/htmlVerifier.spec.js
@@ -10,6 +10,8 @@ const tests = {
   doubleSpaceWithNonBreakingSpace: 'foo \u00a0bar',
   doubleSpaceWithHtmlTag: 'foo <foo> bar</foo>',
   doubleSpaceWithHtmlTagClosing: '<foo>foo </foo> bar',
+  selfClosing: 'foo <bar/> foo',
+  openingWithAttr: 'foo <bar attr="barz"> foo',
 };
 
 describe('validateHTML', () => {

--- a/packages/i18n-lint/src/verifiers/htmlVerifier.js
+++ b/packages/i18n-lint/src/verifiers/htmlVerifier.js
@@ -19,7 +19,7 @@ const noMissingTag = string => {
   const openTags = [];
   const closedTags = [];
 
-  _.forEach(getMatches(string, /<([a-zA-Z]+)>/g, 1), tag => {
+  _.forEach(getMatches(string, /<(\w+)[^/]*>/g, 1), tag => {
     openTags.push(tag);
   });
 


### PR DESCRIPTION
### Why
We need to match opening tags with attributes.

### How
Update the regexp.